### PR TITLE
Add the posibility to choose between areas and lines in the region comparison plot

### DIFF
--- a/tsx/StackedAreas.tsx
+++ b/tsx/StackedAreas.tsx
@@ -50,6 +50,7 @@ export default function StackedAreas() {
     const [useAreas, setUseAreas] = useState(true)
     const [normalize, setNormalize] = useState(false);
     const [currentRegion, setCurrentRegion] = React.useState("All");
+    const keys = ['dimessi_guariti', 'isolamento_domiciliare', 'ricoverati_con_sintomi', 'terapia_intensiva', 'deceduti']
     const fetchData = (newRegion) => {
         fetch('/stacked_area?region=' + newRegion)
             .then(function (response) {
@@ -57,6 +58,7 @@ export default function StackedAreas() {
             })
             .then(function (data) {
                 setData(data)
+ 
             });
     }
     const handleuseAreaChange = (event) => {
@@ -80,10 +82,11 @@ export default function StackedAreas() {
                 top: 10, right: 0, left: 0, bottom: 0,
             }}
         >
+            
             <ReferenceLine x="2020-03-09" label="LockDown" stroke="#EE5555" />
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis dataKey="day" />
-            <YAxis />
+            <YAxis yAxisid={1}    />
             <Tooltip />
             <Area type="monotone" name="Discharged healed" dataKey="dimessi_guariti" stackId="1" stroke="#62f442" fill="#62f442" />
             <Area type="monotone" name="Home isolation" dataKey="isolamento_domiciliare" stackId="1" stroke="#e2c622" fill="#e2c622" />
@@ -102,17 +105,20 @@ export default function StackedAreas() {
                 top: 10, right: 0, left: 0, bottom: 0,
             }}
         >
-            <ReferenceLine x="2020-03-09" label="LockDown" stroke="#EE5555" />
+            
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis dataKey="day" />
-            <YAxis />
+   
+           
             <Tooltip />
-            <Line type="monotone" name="Discharged healed" dataKey="dimessi_guariti" stackId="1" stroke="#62f442" fill="#62f442" />
-            <Line type="monotone" name="Home isolation" dataKey="isolamento_domiciliare" stackId="1" stroke="#e2c622" fill="#e2c622" />
-            <Line type="monotone" name="Hospitalized with symptoms" dataKey="ricoverati_con_sintomi" stackId="1" stroke="#ea701e" fill="#ea701e" />
-            <Line type="monotone" name="Intensive therapy" dataKey="terapia_intensiva" stackId="1" stroke="#ea2b1f" fill="#ea2b1f" />
-            <Line type="monotone" name="Dead" dataKey="deceduti" stackId="1" stroke="#474747" fill="#474747" />
+            <Line type="monotone" name="Discharged healed" dataKey="dimessi_guariti"  stroke="#62f442" fill="#62f442" />
+            <Line type="monotone" name="Home isolation" dataKey="isolamento_domiciliare"  stroke="#e2c622" fill="#e2c622" />
+            <Line type="monotone" name="Hospitalized with symptoms" dataKey="ricoverati_con_sintomi"  stroke="#ea701e" fill="#ea701e" />
+            <Line type="monotone" name="Intensive therapy" dataKey="terapia_intensiva" stroke="#ea2b1f" fill="#ea2b1f" />
+            <Line type="monotone" name="Dead" dataKey="deceduti"  stroke="#474747" fill="#474747" />
             <Legend />
+            <YAxis type="number" domain={[0, dataMax => (dataMax + dataMax*0.1)]}  />
+            <ReferenceLine x="2020-03-09" label="LockDown" stroke="#EE5555" />
             <Brush height={20} dataKey={'day'} />
         </LineChart>)
     }
@@ -150,7 +156,7 @@ export default function StackedAreas() {
             /> : null}
                 </FormGroup>
             <ResponsiveContainer width="100%" height={400}>
-               {useAreas?  TrendsAreaChart() : TrendsLineChart() }
+              { useAreas ? TrendsAreaChart() : TrendsLineChart() }
             </ResponsiveContainer>
         </React.Fragment>)
 }

--- a/tsx/StackedRegions.tsx
+++ b/tsx/StackedRegions.tsx
@@ -1,9 +1,9 @@
 
-import { Checkbox, Chip, FormControlLabel, FormLabel, Input, InputLabel, ListItemText, MenuItem, RadioGroup, Select, FormHelperText, Radio, Divider, Grid, Typography } from '@material-ui/core';
+import { Checkbox, Chip, FormControlLabel, FormLabel, Input, InputLabel, ListItemText, MenuItem, RadioGroup, Select, FormHelperText, Radio, Divider, Grid, Typography, Switch } from '@material-ui/core';
 import FormControl from '@material-ui/core/FormControl';
 import { createStyles, makeStyles, Theme, useTheme } from '@material-ui/core/styles';
 import React, { useEffect, useState } from 'react';
-import { Area, Brush, AreaChart, CartesianGrid, Legend, ReferenceLine, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+import { Area, Brush, AreaChart, LineChart, Line, CartesianGrid, Legend, ReferenceLine, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 declare var regions: any;
 
 const useStylesSelect = makeStyles((theme: Theme) =>
@@ -90,8 +90,8 @@ const options = {
     'tamponi': 'Tamponi'
 }
 export default function StackedRegions() {
-    const theme = useTheme();
 
+    const [useAreas, setUseAreas] = useState(true)
     const [data, setData] = useState(null);
 
     const [normalize, setNormalize] = useState(false);
@@ -107,6 +107,9 @@ export default function StackedRegions() {
                 setData(data)
             });
     }
+    const handleuseAreaChange = (event) => {
+        setUseAreas(event.target.checked)
+    }
     const handleChangeNormalize = (event, newValue) => {
         setNormalize(newValue)
     }
@@ -115,6 +118,59 @@ export default function StackedRegions() {
     };
     const handleWhatChange = (event: React.ChangeEvent<HTMLInputElement>) => {
         setWhat((event.target as HTMLInputElement).value)
+    }
+    const TrendsAreaChart = () => {
+        return (<AreaChart
+            data={data}
+            stackOffset={normalize ? "expand" : "none"}
+            margin={{
+                top: 10, right: 0, left: 0, bottom: 0,
+            }}
+        >
+            <ReferenceLine x="2020-03-09" label="LockDown" stroke="#EE5555" />
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="day" />
+            <YAxis />
+            <Tooltip />
+
+            {selectedRegions.map((elem) => {
+                return <Area type="monotone"
+                    key={elem}
+                    name={elem}
+                    dataKey={elem} stackId="1" stroke={colors[regions.indexOf(elem)]} fill={colors[regions.indexOf(elem)]} />
+            })}
+
+
+            <Legend />
+            <Brush height={20} dataKey={'day'} />
+        </AreaChart>)
+    }
+    const TrendsLineChart = () => {
+
+        return (<LineChart
+            data={data}
+            margin={{
+                top: 10, right: 0, left: 0, bottom: 0,
+            }}
+        >
+            <ReferenceLine x="2020-03-09" label="LockDown" stroke="#EE5555" />
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="day" />
+            <YAxis />
+            <Tooltip />
+
+            {selectedRegions.map((elem) => {
+                return <Line type="monotone"
+                    key={elem}
+                    name={elem}
+                    dataKey={elem} stroke={colors[regions.indexOf(elem)]} fill={colors[regions.indexOf(elem)]} />
+            })}
+
+
+            <Legend />
+            <Brush height={20} dataKey={'day'} />
+        </LineChart>)
+
     }
     useEffect(() => {
         fetchData(selectedRegions)
@@ -154,15 +210,26 @@ export default function StackedRegions() {
                         </MenuItem>
                     ))}
                 </Select>
-            </FormControl> <br />
-            <FormControl className={stylesSelect.formControl}>
+            </FormControl>
+            <Grid component="label" container alignItems="center" spacing={1}>
+                <Grid item>Curves</Grid>
+                <Grid item>
+                    <Switch
+                        checked={useAreas}
+                        onChange={handleuseAreaChange}
+                    />
+                </Grid>
+                <Grid item>Areas</Grid>
+            </Grid>
+            <br />
+            {useAreas ? <FormControl className={stylesSelect.formControl}>
                 <FormControlLabel
                     control={
                         <Checkbox checked={normalize} onChange={handleChangeNormalize} />
                     }
                     label="Normalize"
-                />
-            </FormControl>
+                /> 
+            </FormControl> : null }
             <FormControl component="fieldset" className={stylesSelect.formControl}>
                 <FormLabel component="legend">What to visualize</FormLabel>
                 <RadioGroup row aria-label="what" name="what" value={what} onChange={handleWhatChange}>
@@ -191,32 +258,7 @@ export default function StackedRegions() {
                 {options[what]}
             </Typography>
             <ResponsiveContainer width="100%" height={400}>
-                <AreaChart
-                    width={500}
-                    height={400}
-                    data={data}
-                    stackOffset={normalize ? "expand" : "none"}
-                    margin={{
-                        top: 10, right: 0, left: 0, bottom: 0,
-                    }}
-                >
-                    <ReferenceLine x="2020-03-09" label="LockDown" stroke="#EE5555" />
-                    <CartesianGrid strokeDasharray="3 3" />
-                    <XAxis dataKey="day" />
-                    <YAxis />
-                    <Tooltip />
-
-                    {selectedRegions.map((elem) => {
-                        return <Area type="monotone"
-                            key={elem}
-                            name={elem}
-                            dataKey={elem} stackId="1" stroke={colors[regions.indexOf(elem)]} fill={colors[regions.indexOf(elem)]} />
-                    })}
-
-
-                    <Legend />
-                    <Brush height={20} dataKey={'day'} />
-                </AreaChart>
+                {useAreas ? TrendsAreaChart() : TrendsLineChart()}
             </ResponsiveContainer>
         </React.Fragment>)
 }


### PR DESCRIPTION
This commit add the posibility to choose between areas and lines in the region comparison plot.
It also fixes a bug with the plot values per region.